### PR TITLE
help: add help about execution of ipxe scripts

### DIFF
--- a/obinex/main.go
+++ b/obinex/main.go
@@ -41,8 +41,8 @@ Commands:
     	print this help
   lock [timestring]
     	lock one of the boxes for yourself for the given duration or give information about the lock
-  run <binary> [parameters]
-    	submit the binary for execution (boot parameters are optional)
+  run <binary|ipxe script> [parameters]
+    	submit the binary or ipxe script for execution (boot parameters are optional)
   output <binary>
     	get output for the most recently submitted binary with this name
   reset


### PR DESCRIPTION
The run command can execute both, binaries and ipxe scripts. This adds
an appropriate entry to the help string to let the user know that ipxe
scripts are also accepted.